### PR TITLE
Small change to allow for strictNullChecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/node_module/
+node_modules/
 *.iml
 *.xml
 .idea
+

--- a/src/popper-content.ts
+++ b/src/popper-content.ts
@@ -206,10 +206,10 @@ export class PopperContent implements OnDestroy {
       }
     };
 
-    if (this.popperOptions.boundariesElement) {
-      popperOptions.modifiers.preventOverflow = {
-        boundariesElement: document.querySelector(this.popperOptions.boundariesElement),
-      };
+    let boundariesElement = this.popperOptions.boundariesElement && document.querySelector(this.popperOptions.boundariesElement);
+
+    if (popperOptions.modifiers && boundariesElement) {
+      popperOptions.modifiers.preventOverflow = { boundariesElement };
     }
 
     popperOptions.modifiers = Object.assign(popperOptions.modifiers, this.popperOptions.popperModifiers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
     "lib": [
       "es7",
       "dom",


### PR DESCRIPTION
Re: #5 

Just changed the flow (if condition for `popperOptions.modifiers` potentially being undefined and a slight work around for querySelector returning Element | Null and boundariesElement being typed to `string | Element | undefined` in popper.js types.

Didn't want to make too radical a change, as bit unfamiliar with code base, but the show method could be a bit cleaner.

Also fixed a typo (node_module -> node_modules) in .gitignore