### PR TITLE
fix module default options with forRoot

### DIFF
--- a/src/popper.module.ts
+++ b/src/popper.module.ts
@@ -18,11 +18,7 @@ import {PopperContent} from './popper-content';
   ],
   entryComponents: [
     PopperContent
-  ],
-  providers: [
-    {
-      provide: 'popperDefaults', useValue: {}
-    }]
+  ]
 })
 export class NgxPopperModule {
   ngDoBootstrap() {


### PR DESCRIPTION
this is a very simple fix, after this, we can use `forRoot` in AppModule to specify the default options.

current design will ignore any options, even specified in `forRoot`