### PR TITLE
Get rid of unecessary clearTimeout()

### DIFF
--- a/src/popper-directive.ts
+++ b/src/popper-directive.ts
@@ -235,8 +235,8 @@ export class PopperController implements OnInit, OnDestroy, OnChanges {
     this.subscriptions.length = 0;
     this.clearEventListeners();
     this.clearGlobalEventListeners();
-    clearTimeout(this.scheduledShowTimeout);
-    clearTimeout(this.scheduledHideTimeout);
+    if (this.scheduledShowTimeout !== undefined) clearTimeout(this.scheduledShowTimeout);
+    if (this.scheduledHideTimeout !== undefined) clearTimeout(this.scheduledHideTimeout);
     this.popperContent && this.popperContent.clean();
   }
 


### PR DESCRIPTION
Performance improvement: 
Added condition to `clearTimeout(...)`, so it only runs if a timeout was started.

Fixes MrFrankel/ngx-popper#126 