### PR TITLE
ModuleWithProviders GenericType

### DIFF
--- a/src/popper.module.ts
+++ b/src/popper.module.ts
@@ -24,7 +24,7 @@ export class NgxPopperModule {
   ngDoBootstrap() {
   }
 
-  public static forRoot(popperBaseOptions: PopperContentOptions = {}): ModuleWithProviders {
+  public static forRoot(popperBaseOptions: PopperContentOptions = {}): ModuleWithProviders<NgxPopperModule> {
     return {ngModule: NgxPopperModule, providers: [{provide: 'popperDefaults', useValue: popperBaseOptions}]};
   }
 }


### PR DESCRIPTION
Hi guys,

I run into following issue while updating to angular 10:
ERROR: node_modules/ngx-popper/src/popper.module.d.ts:5:63 - error TS2314: Generic type 'ModuleWithProviders<T>' requires 1 type argument(s).

More info can be found [here](https://angular.io/guide/migration-module-with-providers#why-is-this-migration-necessary).

Please let me know if there is something I missed.